### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ A [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that
 provides access to Dutch weather data via the KNMI (Royal Netherlands
 Meteorological Institute) API.
 
+<a href="https://glama.ai/mcp/servers/@dstotijn/knmi-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@dstotijn/knmi-mcp/badge" alt="KNMI Server MCP server" />
+</a>
+
 ## Overview
 
 This MCP server enables AI assistants and applications to access comprehensive


### PR DESCRIPTION
This PR adds a badge for the [KNMI MCP Server](https://glama.ai/mcp/servers/@dstotijn/knmi-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@dstotijn/knmi-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@dstotijn/knmi-mcp/badge" alt="KNMI Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.